### PR TITLE
Fix warnings in tests output about textual SQL expression which should be explicitly declared as text

### DIFF
--- a/scripts/populate_subscription_tiers.py
+++ b/scripts/populate_subscription_tiers.py
@@ -23,6 +23,7 @@ from uuid import UUID, uuid4
 
 from dotenv import load_dotenv
 from loguru import logger
+from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 from sqlalchemy.orm import sessionmaker
 
@@ -208,13 +209,13 @@ async def populate_subscription_tiers(test_mode: bool = False):
                 existing_plan = None
                 try:
                     if plan_data["stripe_product_id"]:
-                        result = await session.execute(
+                        result = await session.execute(text(
                             f"SELECT id FROM subscription_tier WHERE stripe_product_id = '{plan_data['stripe_product_id']}'"
-                        )
+                        ))
                     else:
-                        result = await session.execute(
+                        result = await session.execute(text(
                             f"SELECT id FROM subscription_tier WHERE name = '{plan_data['name']}'"
-                        )
+                        ))
                     existing_plan = result.scalar_one_or_none()
                 except Exception as e:
                     logger.warning(f"Error checking for existing plan {plan_name}: {str(e)}")


### PR DESCRIPTION
@bilalesi This just fixes some warnings which are logged when the tests are being executed:

2026-03-20 16:08:20.151 | WARNING  | scripts.populate_subscription_tiers:populate_subscription_tiers:220 - Error checking for existing plan Free: Textual SQL expression 'SELECT id FROM subscripti...' should be explicitly declared as text('SELECT id FROM subscripti...')