### PR TITLE
MULTIPLE_VLABS_ALLOWED_USER_ID

### DIFF
--- a/virtual_labs/core/authorization/verify_uniqueness_virtual_lab.py
+++ b/virtual_labs/core/authorization/verify_uniqueness_virtual_lab.py
@@ -19,7 +19,7 @@ async def verify_uniq_virtual_lab(
     """Dependency that raises if the authenticated user already owns a virtual lab."""
     owner_id = get_user_id_from_auth(auth)
 
-    if owner_id == settings.MULTIPLE_VLABS_ALLOWED_USER_IDS:
+    if owner_id == settings.MULTIPLE_VLABS_ALLOWED_USER_ID:
         return
 
     existing = await get_user_virtual_lab(db=db, owner_id=owner_id)

--- a/virtual_labs/infrastructure/settings.py
+++ b/virtual_labs/infrastructure/settings.py
@@ -109,7 +109,7 @@ class Settings(BaseSettings):
 
     # There's a single configuration set in staging and production with a static name
     AWS_SES_CONFIGURATION_SET: str = "main-ses-config"
-    MULTIPLE_VLABS_ALLOWED_USER_IDS: UUID4 = UUID(
+    MULTIPLE_VLABS_ALLOWED_USER_ID: UUID4 = UUID(
         "16588c8b-ec88-4a49-a413-a0bb3a7b8541"
     )  # id of 'obi-virtual-lab' user in staging
 


### PR DESCRIPTION
Sorry @bilalesi minor update since it's a single id I put it in singular for clarity.