### PR TITLE
feat: require `email` and `country` on user profile endpoints

### DIFF
--- a/dev-init.sh
+++ b/dev-init.sh
@@ -61,6 +61,16 @@ fi
 # Additional wait to ensure realm is fully imported
 sleep 5
 
+# Disable SSL requirement on the master realm so the admin console is accessible over HTTP locally
+echo "disabling SSL requirement on master realm..."
+docker exec keycloak /opt/keycloak/bin/kcadm.sh config credentials \
+  --server http://localhost:9090 \
+  --realm master \
+  --user admin \
+  --password admin
+docker exec keycloak /opt/keycloak/bin/kcadm.sh update realms/master -s sslRequired=NONE
+echo "master realm ssl requirement disabled."
+
 make init-db
 
 echo "get access token"

--- a/dev-init.sh
+++ b/dev-init.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 set -o errexit
-set -x
 # Keycloak details - replace these with your actual values
 KC_SERVER_URI="http://localhost:9090"
 KC_REALM_NAME="obp-realm"
@@ -63,26 +62,22 @@ sleep 5
 
 # disable SSL requirement on the master realm so the admin console is accessible over HTTP locally
 echo "disabling SSL requirement on master realm..."
+echo "🔐 Configuring Keycloak admin credentials..."
 docker exec keycloak /opt/keycloak/bin/kcadm.sh config credentials \
   --server http://localhost:9090 \
   --realm master \
   --user admin \
   --password admin
 docker exec keycloak /opt/keycloak/bin/kcadm.sh update realms/master -s sslRequired=NONE
-echo "master realm ssl requirement disabled."
+echo "✅ Master realm SSL requirement disabled"
 
-# ensure email verification is disabled on the test realm to prevent
-# "Account is not fully set up" errors when tests change user emails
+echo "🔧 Disabling email/profile verification for test realm..."
 docker exec keycloak /opt/keycloak/bin/kcadm.sh update realms/obp-realm -s verifyEmail=false
-
-# disable VERIFY_EMAIL and VERIFY_PROFILE required actions to prevent
-# "Account is not fully set up" errors during direct grant token requests
-# after profile updates via the admin API
 docker exec keycloak /opt/keycloak/bin/kcadm.sh update authentication/required-actions/VERIFY_EMAIL -r obp-realm -s enabled=false
 docker exec keycloak /opt/keycloak/bin/kcadm.sh update authentication/required-actions/VERIFY_PROFILE -r obp-realm -s enabled=false
+echo "✅ VERIFY_EMAIL and VERIFY_PROFILE disabled"
 
-# Register custom user attributes in the User Profile so they are persisted
-# by the admin API. Use "ADMIN_EDIT" policy for any undeclared attributes.
+echo "📋 Registering custom user profile attributes..."
 cat > /tmp/kc-user-profile.json <<'EOF'
 {
   "unmanagedAttributePolicy": "ADMIN_EDIT",
@@ -159,6 +154,7 @@ EOF
 docker cp /tmp/kc-user-profile.json keycloak:/tmp/kc-user-profile.json
 docker exec keycloak /opt/keycloak/bin/kcadm.sh update realms/obp-realm/users/profile -r obp-realm -f /tmp/kc-user-profile.json
 rm -f /tmp/kc-user-profile.json
+echo "✅ User profile attributes registered (country, street, postal_code, locality, region, plan, virtual_lab_id)"
 
 make init-db
 

--- a/dev-init.sh
+++ b/dev-init.sh
@@ -61,7 +61,7 @@ fi
 # Additional wait to ensure realm is fully imported
 sleep 5
 
-# Disable SSL requirement on the master realm so the admin console is accessible over HTTP locally
+# disable SSL requirement on the master realm so the admin console is accessible over HTTP locally
 echo "disabling SSL requirement on master realm..."
 docker exec keycloak /opt/keycloak/bin/kcadm.sh config credentials \
   --server http://localhost:9090 \
@@ -70,6 +70,95 @@ docker exec keycloak /opt/keycloak/bin/kcadm.sh config credentials \
   --password admin
 docker exec keycloak /opt/keycloak/bin/kcadm.sh update realms/master -s sslRequired=NONE
 echo "master realm ssl requirement disabled."
+
+# ensure email verification is disabled on the test realm to prevent
+# "Account is not fully set up" errors when tests change user emails
+docker exec keycloak /opt/keycloak/bin/kcadm.sh update realms/obp-realm -s verifyEmail=false
+
+# disable VERIFY_EMAIL and VERIFY_PROFILE required actions to prevent
+# "Account is not fully set up" errors during direct grant token requests
+# after profile updates via the admin API
+docker exec keycloak /opt/keycloak/bin/kcadm.sh update authentication/required-actions/VERIFY_EMAIL -r obp-realm -s enabled=false
+docker exec keycloak /opt/keycloak/bin/kcadm.sh update authentication/required-actions/VERIFY_PROFILE -r obp-realm -s enabled=false
+
+# Register custom user attributes in the User Profile so they are persisted
+# by the admin API. Use "ADMIN_EDIT" policy for any undeclared attributes.
+cat > /tmp/kc-user-profile.json <<'EOF'
+{
+  "unmanagedAttributePolicy": "ADMIN_EDIT",
+  "attributes": [
+    {
+      "name": "username",
+      "displayName": "${username}",
+      "permissions": { "view": ["admin", "user"], "edit": ["admin"] },
+      "validations": { "length": { "min": 3, "max": 255 }, "username-prohibited-characters": {} }
+    },
+    {
+      "name": "email",
+      "displayName": "${email}",
+      "permissions": { "view": ["admin", "user"], "edit": ["admin", "user"] },
+      "validations": { "email": {}, "length": { "max": 255 } }
+    },
+    {
+      "name": "firstName",
+      "displayName": "${firstName}",
+      "permissions": { "view": ["admin", "user"], "edit": ["admin", "user"] },
+      "validations": { "length": { "max": 255 }, "person-name-prohibited-characters": {} }
+    },
+    {
+      "name": "lastName",
+      "displayName": "${lastName}",
+      "permissions": { "view": ["admin", "user"], "edit": ["admin", "user"] },
+      "validations": { "length": { "max": 255 }, "person-name-prohibited-characters": {} }
+    },
+    {
+      "name": "country",
+      "displayName": "Country",
+      "permissions": { "view": ["admin", "user"], "edit": ["admin", "user"] },
+      "validations": {}
+    },
+    {
+      "name": "street",
+      "displayName": "Street",
+      "permissions": { "view": ["admin", "user"], "edit": ["admin", "user"] },
+      "validations": {}
+    },
+    {
+      "name": "postal_code",
+      "displayName": "Postal Code",
+      "permissions": { "view": ["admin", "user"], "edit": ["admin", "user"] },
+      "validations": {}
+    },
+    {
+      "name": "locality",
+      "displayName": "Locality",
+      "permissions": { "view": ["admin", "user"], "edit": ["admin", "user"] },
+      "validations": {}
+    },
+    {
+      "name": "region",
+      "displayName": "Region",
+      "permissions": { "view": ["admin", "user"], "edit": ["admin", "user"] },
+      "validations": {}
+    },
+    {
+      "name": "plan",
+      "displayName": "Subscription Plan",
+      "permissions": { "view": ["admin", "user"], "edit": ["admin"] },
+      "validations": {}
+    },
+    {
+      "name": "virtual_lab_id",
+      "displayName": "Virtual Lab ID",
+      "permissions": { "view": ["admin", "user"], "edit": ["admin"] },
+      "validations": {}
+    }
+  ]
+}
+EOF
+docker cp /tmp/kc-user-profile.json keycloak:/tmp/kc-user-profile.json
+docker exec keycloak /opt/keycloak/bin/kcadm.sh update realms/obp-realm/users/profile -r obp-realm -f /tmp/kc-user-profile.json
+rm -f /tmp/kc-user-profile.json
 
 make init-db
 

--- a/env-prep/realm-export.json
+++ b/env-prep/realm-export.json
@@ -1085,10 +1085,10 @@
         "acr",
         "roles",
         "profile",
-        "email"
+        "email",
+        "address"
       ],
       "optionalClientScopes": [
-        "address",
         "phone",
         "offline_access",
         "microprofile-jwt"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,8 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.pytest.ini_options]
 asyncio_mode = "strict"
+testpaths = ["virtual_labs"]
+norecursedirs = ["virtual_labs/tests/bookmarks"]
 
 markers = [
   "integration: mark a test as an integration test"

--- a/virtual_labs/api.py
+++ b/virtual_labs/api.py
@@ -6,6 +6,7 @@ import sentry_sdk
 from fastapi import FastAPI, Request
 from fastapi.encoders import jsonable_encoder
 from fastapi.exceptions import RequestValidationError
+from fastapi.middleware.gzip import GZipMiddleware
 from fastapi.openapi.utils import get_openapi
 from fastapi.responses import JSONResponse
 from fastapi.routing import APIRouter
@@ -26,6 +27,7 @@ from virtual_labs.infrastructure.settings import settings
 from virtual_labs.routes.accounting import router as accounting_router
 from virtual_labs.routes.bookmarks import router as bookmarks_router
 from virtual_labs.routes.common import router as common_router
+from virtual_labs.routes.config import router as config_router
 from virtual_labs.routes.invites import router as invite_router
 from virtual_labs.routes.labs import router as virtual_lab_router
 from virtual_labs.routes.payments import router as payments_router
@@ -73,6 +75,8 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+
+app.add_middleware(GZipMiddleware, minimum_size=1000)
 
 
 def custom_openapi() -> dict[str, Any]:
@@ -182,5 +186,6 @@ base_router.include_router(subscription_router)
 base_router.include_router(user_router)
 base_router.include_router(promotions_router)
 base_router.include_router(admin_promotions_router)
+base_router.include_router(config_router)
 
 app.include_router(base_router)

--- a/virtual_labs/domain/user.py
+++ b/virtual_labs/domain/user.py
@@ -71,6 +71,15 @@ class UserAgentResponse(BaseModel):
     type: list[str]
 
 
+class UpdateAddress(BaseModel):
+    """Address payload for profile updates"""
+
+    street: Optional[str] = None
+    postal_code: Optional[str] = None
+    locality: Optional[str] = None
+    region: Optional[str] = None
+
+
 class Address(BaseModel):
     """User address information"""
 
@@ -101,10 +110,11 @@ class UserProfile(BaseModel):
 
 
 class UpdateUserProfileRequest(BaseModel):
-    email: Optional[EmailStr] = None
+    email: EmailStr
+    country: str
     first_name: Optional[str] = None
     last_name: Optional[str] = None
-    address: Optional[Address] = None
+    address: Optional[UpdateAddress] = None
 
 
 class UserProfileResponse(BaseModel):

--- a/virtual_labs/domain/user.py
+++ b/virtual_labs/domain/user.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+import json
 from datetime import datetime
 from enum import Enum
+from pathlib import Path
 from typing import TYPE_CHECKING, Annotated, Any, List, Optional, TypedDict
 
 from pydantic import (
@@ -22,6 +24,15 @@ from virtual_labs.infrastructure.db.models import SpeciesSelectionMode
 if TYPE_CHECKING:
     from virtual_labs.domain.labs import VirtualLabDetails
     from virtual_labs.domain.project import ProjectVlOut
+
+_VALID_COUNTRY_CODES: set[str] = {
+    entry["code"]
+    for entry in json.loads(
+        (Path(__file__).resolve().parent.parent / "static" / "country.json").read_text(
+            encoding="utf-8"
+        )
+    )
+}
 
 
 class ShortenedUser(BaseModel):
@@ -118,9 +129,18 @@ class UpdateUserProfileRequest(BaseModel):
 
 
 class OnboardingUpdateUserProfileRequest(BaseModel):
-    country: Optional[str] = None
-    first_name: Optional[str] = None
-    last_name: Optional[str] = None
+    email: EmailStr
+    country: str
+    first_name: str
+    last_name: str
+
+    @field_validator("country")
+    @classmethod
+    def validate_country_code(cls, v: str) -> str:
+        code = v.upper()
+        if code not in _VALID_COUNTRY_CODES:
+            raise ValueError(f"Invalid country code: {v}")
+        return code
 
 
 class UserProfileResponse(BaseModel):

--- a/virtual_labs/domain/user.py
+++ b/virtual_labs/domain/user.py
@@ -117,6 +117,12 @@ class UpdateUserProfileRequest(BaseModel):
     address: Optional[UpdateAddress] = None
 
 
+class OnboardingUpdateUserProfileRequest(BaseModel):
+    country: Optional[str] = None
+    first_name: Optional[str] = None
+    last_name: Optional[str] = None
+
+
 class UserProfileResponse(BaseModel):
     profile: UserProfile
 

--- a/virtual_labs/domain/user.py
+++ b/virtual_labs/domain/user.py
@@ -122,15 +122,23 @@ class UserProfile(BaseModel):
 
 class UpdateUserProfileRequest(BaseModel):
     email: EmailStr
-    country: str
-    first_name: Optional[str] = None
-    last_name: Optional[str] = None
+    country: str = Field(min_length=2, max_length=2)
+    first_name: str
+    last_name: str
     address: Optional[UpdateAddress] = None
+
+    @field_validator("country")
+    @classmethod
+    def validate_country_code(cls, v: str) -> str:
+        code = v.upper()
+        if code not in _VALID_COUNTRY_CODES:
+            raise ValueError(f"Invalid ISO 3166-1 alpha-2 country code: {v}")
+        return code
 
 
 class OnboardingUpdateUserProfileRequest(BaseModel):
     email: EmailStr
-    country: str
+    country: str = Field(min_length=2, max_length=2)
     first_name: str
     last_name: str
 
@@ -139,7 +147,7 @@ class OnboardingUpdateUserProfileRequest(BaseModel):
     def validate_country_code(cls, v: str) -> str:
         code = v.upper()
         if code not in _VALID_COUNTRY_CODES:
-            raise ValueError(f"Invalid country code: {v}")
+            raise ValueError(f"Invalid ISO 3166-1 alpha-2 country code: {v}")
         return code
 
 

--- a/virtual_labs/repositories/labs.py
+++ b/virtual_labs/repositories/labs.py
@@ -118,7 +118,7 @@ async def create_virtual_lab(db: AsyncSession, lab: VirtualLabDbCreate) -> Virtu
         compute_cell=lab.compute_cell,
     )
     db.add(db_lab)
-    await db.commit()
+    await db.flush()
     await db.refresh(db_lab)
     return db_lab
 

--- a/virtual_labs/repositories/user_repo.py
+++ b/virtual_labs/repositories/user_repo.py
@@ -108,6 +108,11 @@ class UserQueryRepository:
     async def get_user_info(self, token: str) -> UserInfo:
         return cast(UserInfo, await self.Kc_auth.a_userinfo(token=token))
 
+    async def a_check_email_exists(self, email: str) -> bool:
+        """Check if an email is already registered in Keycloak (async)."""
+        users = await self.Kc.a_get_users({"email": email, "exact": "true"})
+        return isinstance(users, list) and len(users) > 0
+
 
 class UserMutationRepository:
     Kc: KeycloakAdmin

--- a/virtual_labs/routes/config.py
+++ b/virtual_labs/routes/config.py
@@ -1,0 +1,17 @@
+from pathlib import Path
+
+from fastapi import APIRouter, Response
+
+COUNTRY = (Path(__file__).parent.parent / "static/country.json").open().read()
+
+
+def read_countries() -> Response:
+    return Response(content=COUNTRY, media_type="application/json")
+
+
+router = APIRouter(
+    prefix="/config",
+    tags=["Configuration"],
+)
+
+read_countries = router.get("/countries")(read_countries)

--- a/virtual_labs/routes/user.py
+++ b/virtual_labs/routes/user.py
@@ -1,3 +1,4 @@
+from http import HTTPStatus
 from typing import Annotated, Dict, Tuple
 
 from fastapi import APIRouter, Depends, Header, Response
@@ -37,6 +38,7 @@ from virtual_labs.infrastructure.redis.email_rate_limit import (
 from virtual_labs.usecases import email_verification as email_verification_usecases
 from virtual_labs.usecases.labs.get_user_stats import get_user_stats
 from virtual_labs.usecases.users import (
+    check_email_availability,
     get_user_onboarding_status,
     get_user_profile,
     get_workspace_hierarchy_species_preference,
@@ -130,6 +132,25 @@ async def update_onboarding_user_profile(
         auth=auth,
         session=session,
     )
+
+
+@router.get(
+    "/profile/email/_check",
+    summary="Check email availability",
+    description="Check if an email address is available for use during onboarding. Returns 204 if available, 422 if already taken.",
+    status_code=HTTPStatus.NO_CONTENT,
+)
+async def check_email_availability_endpoint(
+    email: EmailStr,
+    auth: Tuple[AuthUser, str] = Depends(a_verify_jwt),
+) -> Response:
+    """
+    Check whether the provided email is available for the authenticated user.
+
+    Returns:
+        204 No Content if available, 422 if already taken.
+    """
+    return await check_email_availability(email=email, auth=auth)
 
 
 @router.get(

--- a/virtual_labs/routes/user.py
+++ b/virtual_labs/routes/user.py
@@ -15,6 +15,7 @@ from virtual_labs.domain.user import (
     OnboardingFeature,
     OnboardingStatus,
     OnboardingUpdateRequest,
+    OnboardingUpdateUserProfileRequest,
     SetRecentWorkspaceRequest,
     UpdateUserProfileRequest,
     UserGroupsResponse,
@@ -39,6 +40,7 @@ from virtual_labs.usecases.users import (
     get_user_onboarding_status,
     get_user_profile,
     get_workspace_hierarchy_species_preference,
+    onboarding_update_user_profile,
     reset_all_user_onboarding_status,
     reset_user_onboarding_status,
     set_recent_workspace,
@@ -96,6 +98,34 @@ async def update_profile_endpoint(
         Response: the updated user profile information
     """
     return await update_user_profile(
+        payload=payload,
+        auth=auth,
+        session=session,
+    )
+
+
+@router.patch(
+    "/onboarding/profile",
+    summary="Update user profile",
+    description="Update the profile information for the authenticated user",
+    response_model=VliAppResponse[UserProfileResponse],
+    response_model_exclude_none=False,
+)
+async def update_onboarding_user_profile(
+    payload: OnboardingUpdateUserProfileRequest,
+    session: AsyncSession = Depends(default_session_factory),
+    auth: Tuple[AuthUser, str] = Depends(a_verify_jwt),
+) -> Response:
+    """
+    update the profile information for the authenticated user.
+
+    Args:
+        payload: The user profile data to update
+
+    Returns:
+        Response: the updated user profile information
+    """
+    return await onboarding_update_user_profile(
         payload=payload,
         auth=auth,
         session=session,

--- a/virtual_labs/static/country.json
+++ b/virtual_labs/static/country.json
@@ -1,0 +1,998 @@
+[
+  {
+    "name": "Afghanistan",
+    "code": "AF"
+  },
+  {
+    "name": "Åland Islands",
+    "code": "AX"
+  },
+  {
+    "name": "Albania",
+    "code": "AL"
+  },
+  {
+    "name": "Algeria",
+    "code": "DZ"
+  },
+  {
+    "name": "American Samoa",
+    "code": "AS"
+  },
+  {
+    "name": "Andorra",
+    "code": "AD"
+  },
+  {
+    "name": "Angola",
+    "code": "AO"
+  },
+  {
+    "name": "Anguilla",
+    "code": "AI"
+  },
+  {
+    "name": "Antarctica",
+    "code": "AQ"
+  },
+  {
+    "name": "Antigua and Barbuda",
+    "code": "AG"
+  },
+  {
+    "name": "Argentina",
+    "code": "AR"
+  },
+  {
+    "name": "Armenia",
+    "code": "AM"
+  },
+  {
+    "name": "Aruba",
+    "code": "AW"
+  },
+  {
+    "name": "Australia",
+    "code": "AU"
+  },
+  {
+    "name": "Austria",
+    "code": "AT"
+  },
+  {
+    "name": "Azerbaijan",
+    "code": "AZ"
+  },
+  {
+    "name": "Bahamas",
+    "code": "BS"
+  },
+  {
+    "name": "Bahrain",
+    "code": "BH"
+  },
+  {
+    "name": "Bangladesh",
+    "code": "BD"
+  },
+  {
+    "name": "Barbados",
+    "code": "BB"
+  },
+  {
+    "name": "Belarus",
+    "code": "BY"
+  },
+  {
+    "name": "Belgium",
+    "code": "BE"
+  },
+  {
+    "name": "Belize",
+    "code": "BZ"
+  },
+  {
+    "name": "Benin",
+    "code": "BJ"
+  },
+  {
+    "name": "Bermuda",
+    "code": "BM"
+  },
+  {
+    "name": "Bhutan",
+    "code": "BT"
+  },
+  {
+    "name": "Bolivia, Plurinational State of",
+    "code": "BO"
+  },
+  {
+    "name": "Bonaire, Sint Eustatius and Saba",
+    "code": "BQ"
+  },
+  {
+    "name": "Bosnia and Herzegovina",
+    "code": "BA"
+  },
+  {
+    "name": "Botswana",
+    "code": "BW"
+  },
+  {
+    "name": "Bouvet Island",
+    "code": "BV"
+  },
+  {
+    "name": "Brazil",
+    "code": "BR"
+  },
+  {
+    "name": "British Indian Ocean Territory",
+    "code": "IO"
+  },
+  {
+    "name": "Brunei Darussalam",
+    "code": "BN"
+  },
+  {
+    "name": "Bulgaria",
+    "code": "BG"
+  },
+  {
+    "name": "Burkina Faso",
+    "code": "BF"
+  },
+  {
+    "name": "Burundi",
+    "code": "BI"
+  },
+  {
+    "name": "Cambodia",
+    "code": "KH"
+  },
+  {
+    "name": "Cameroon",
+    "code": "CM"
+  },
+  {
+    "name": "Canada",
+    "code": "CA"
+  },
+  {
+    "name": "Cape Verde",
+    "code": "CV"
+  },
+  {
+    "name": "Cayman Islands",
+    "code": "KY"
+  },
+  {
+    "name": "Central African Republic",
+    "code": "CF"
+  },
+  {
+    "name": "Chad",
+    "code": "TD"
+  },
+  {
+    "name": "Chile",
+    "code": "CL"
+  },
+  {
+    "name": "China",
+    "code": "CN"
+  },
+  {
+    "name": "Christmas Island",
+    "code": "CX"
+  },
+  {
+    "name": "Cocos (Keeling) Islands",
+    "code": "CC"
+  },
+  {
+    "name": "Colombia",
+    "code": "CO"
+  },
+  {
+    "name": "Comoros",
+    "code": "KM"
+  },
+  {
+    "name": "Congo",
+    "code": "CG"
+  },
+  {
+    "name": "Congo, the Democratic Republic of the",
+    "code": "CD"
+  },
+  {
+    "name": "Cook Islands",
+    "code": "CK"
+  },
+  {
+    "name": "Costa Rica",
+    "code": "CR"
+  },
+  {
+    "name": "Côte d'Ivoire",
+    "code": "CI"
+  },
+  {
+    "name": "Croatia",
+    "code": "HR"
+  },
+  {
+    "name": "Cuba",
+    "code": "CU"
+  },
+  {
+    "name": "Curaçao",
+    "code": "CW"
+  },
+  {
+    "name": "Cyprus",
+    "code": "CY"
+  },
+  {
+    "name": "Czech Republic",
+    "code": "CZ"
+  },
+  {
+    "name": "Denmark",
+    "code": "DK"
+  },
+  {
+    "name": "Djibouti",
+    "code": "DJ"
+  },
+  {
+    "name": "Dominica",
+    "code": "DM"
+  },
+  {
+    "name": "Dominican Republic",
+    "code": "DO"
+  },
+  {
+    "name": "Ecuador",
+    "code": "EC"
+  },
+  {
+    "name": "Egypt",
+    "code": "EG"
+  },
+  {
+    "name": "El Salvador",
+    "code": "SV"
+  },
+  {
+    "name": "Equatorial Guinea",
+    "code": "GQ"
+  },
+  {
+    "name": "Eritrea",
+    "code": "ER"
+  },
+  {
+    "name": "Estonia",
+    "code": "EE"
+  },
+  {
+    "name": "Ethiopia",
+    "code": "ET"
+  },
+  {
+    "name": "Falkland Islands (Malvinas)",
+    "code": "FK"
+  },
+  {
+    "name": "Faroe Islands",
+    "code": "FO"
+  },
+  {
+    "name": "Fiji",
+    "code": "FJ"
+  },
+  {
+    "name": "Finland",
+    "code": "FI"
+  },
+  {
+    "name": "France",
+    "code": "FR"
+  },
+  {
+    "name": "French Guiana",
+    "code": "GF"
+  },
+  {
+    "name": "French Polynesia",
+    "code": "PF"
+  },
+  {
+    "name": "French Southern Territories",
+    "code": "TF"
+  },
+  {
+    "name": "Gabon",
+    "code": "GA"
+  },
+  {
+    "name": "Gambia",
+    "code": "GM"
+  },
+  {
+    "name": "Georgia",
+    "code": "GE"
+  },
+  {
+    "name": "Germany",
+    "code": "DE"
+  },
+  {
+    "name": "Ghana",
+    "code": "GH"
+  },
+  {
+    "name": "Gibraltar",
+    "code": "GI"
+  },
+  {
+    "name": "Greece",
+    "code": "GR"
+  },
+  {
+    "name": "Greenland",
+    "code": "GL"
+  },
+  {
+    "name": "Grenada",
+    "code": "GD"
+  },
+  {
+    "name": "Guadeloupe",
+    "code": "GP"
+  },
+  {
+    "name": "Guam",
+    "code": "GU"
+  },
+  {
+    "name": "Guatemala",
+    "code": "GT"
+  },
+  {
+    "name": "Guernsey",
+    "code": "GG"
+  },
+  {
+    "name": "Guinea",
+    "code": "GN"
+  },
+  {
+    "name": "Guinea-Bissau",
+    "code": "GW"
+  },
+  {
+    "name": "Guyana",
+    "code": "GY"
+  },
+  {
+    "name": "Haiti",
+    "code": "HT"
+  },
+  {
+    "name": "Heard Island and McDonald Islands",
+    "code": "HM"
+  },
+  {
+    "name": "Holy See (Vatican City State)",
+    "code": "VA"
+  },
+  {
+    "name": "Honduras",
+    "code": "HN"
+  },
+  {
+    "name": "Hong Kong",
+    "code": "HK"
+  },
+  {
+    "name": "Hungary",
+    "code": "HU"
+  },
+  {
+    "name": "Iceland",
+    "code": "IS"
+  },
+  {
+    "name": "India",
+    "code": "IN"
+  },
+  {
+    "name": "Indonesia",
+    "code": "ID"
+  },
+  {
+    "name": "Iran, Islamic Republic of",
+    "code": "IR"
+  },
+  {
+    "name": "Iraq",
+    "code": "IQ"
+  },
+  {
+    "name": "Ireland",
+    "code": "IE"
+  },
+  {
+    "name": "Isle of Man",
+    "code": "IM"
+  },
+  {
+    "name": "Israel",
+    "code": "IL"
+  },
+  {
+    "name": "Italy",
+    "code": "IT"
+  },
+  {
+    "name": "Jamaica",
+    "code": "JM"
+  },
+  {
+    "name": "Japan",
+    "code": "JP"
+  },
+  {
+    "name": "Jersey",
+    "code": "JE"
+  },
+  {
+    "name": "Jordan",
+    "code": "JO"
+  },
+  {
+    "name": "Kazakhstan",
+    "code": "KZ"
+  },
+  {
+    "name": "Kenya",
+    "code": "KE"
+  },
+  {
+    "name": "Kiribati",
+    "code": "KI"
+  },
+  {
+    "name": "Korea, Democratic People's Republic of",
+    "code": "KP"
+  },
+  {
+    "name": "Korea, Republic of",
+    "code": "KR"
+  },
+  {
+    "name": "Kuwait",
+    "code": "KW"
+  },
+  {
+    "name": "Kyrgyzstan",
+    "code": "KG"
+  },
+  {
+    "name": "Lao People's Democratic Republic",
+    "code": "LA"
+  },
+  {
+    "name": "Latvia",
+    "code": "LV"
+  },
+  {
+    "name": "Lebanon",
+    "code": "LB"
+  },
+  {
+    "name": "Lesotho",
+    "code": "LS"
+  },
+  {
+    "name": "Liberia",
+    "code": "LR"
+  },
+  {
+    "name": "Libya",
+    "code": "LY"
+  },
+  {
+    "name": "Liechtenstein",
+    "code": "LI"
+  },
+  {
+    "name": "Lithuania",
+    "code": "LT"
+  },
+  {
+    "name": "Luxembourg",
+    "code": "LU"
+  },
+  {
+    "name": "Macao",
+    "code": "MO"
+  },
+  {
+    "name": "Macedonia, the Former Yugoslav Republic of",
+    "code": "MK"
+  },
+  {
+    "name": "Madagascar",
+    "code": "MG"
+  },
+  {
+    "name": "Malawi",
+    "code": "MW"
+  },
+  {
+    "name": "Malaysia",
+    "code": "MY"
+  },
+  {
+    "name": "Maldives",
+    "code": "MV"
+  },
+  {
+    "name": "Mali",
+    "code": "ML"
+  },
+  {
+    "name": "Malta",
+    "code": "MT"
+  },
+  {
+    "name": "Marshall Islands",
+    "code": "MH"
+  },
+  {
+    "name": "Martinique",
+    "code": "MQ"
+  },
+  {
+    "name": "Mauritania",
+    "code": "MR"
+  },
+  {
+    "name": "Mauritius",
+    "code": "MU"
+  },
+  {
+    "name": "Mayotte",
+    "code": "YT"
+  },
+  {
+    "name": "Mexico",
+    "code": "MX"
+  },
+  {
+    "name": "Micronesia, Federated States of",
+    "code": "FM"
+  },
+  {
+    "name": "Moldova, Republic of",
+    "code": "MD"
+  },
+  {
+    "name": "Monaco",
+    "code": "MC"
+  },
+  {
+    "name": "Mongolia",
+    "code": "MN"
+  },
+  {
+    "name": "Montenegro",
+    "code": "ME"
+  },
+  {
+    "name": "Montserrat",
+    "code": "MS"
+  },
+  {
+    "name": "Morocco",
+    "code": "MA"
+  },
+  {
+    "name": "Mozambique",
+    "code": "MZ"
+  },
+  {
+    "name": "Myanmar",
+    "code": "MM"
+  },
+  {
+    "name": "Namibia",
+    "code": "NA"
+  },
+  {
+    "name": "Nauru",
+    "code": "NR"
+  },
+  {
+    "name": "Nepal",
+    "code": "NP"
+  },
+  {
+    "name": "Netherlands",
+    "code": "NL"
+  },
+  {
+    "name": "New Caledonia",
+    "code": "NC"
+  },
+  {
+    "name": "New Zealand",
+    "code": "NZ"
+  },
+  {
+    "name": "Nicaragua",
+    "code": "NI"
+  },
+  {
+    "name": "Niger",
+    "code": "NE"
+  },
+  {
+    "name": "Nigeria",
+    "code": "NG"
+  },
+  {
+    "name": "Niue",
+    "code": "NU"
+  },
+  {
+    "name": "Norfolk Island",
+    "code": "NF"
+  },
+  {
+    "name": "Northern Mariana Islands",
+    "code": "MP"
+  },
+  {
+    "name": "Norway",
+    "code": "NO"
+  },
+  {
+    "name": "Oman",
+    "code": "OM"
+  },
+  {
+    "name": "Pakistan",
+    "code": "PK"
+  },
+  {
+    "name": "Palau",
+    "code": "PW"
+  },
+  {
+    "name": "Palestine, State of",
+    "code": "PS"
+  },
+  {
+    "name": "Panama",
+    "code": "PA"
+  },
+  {
+    "name": "Papua New Guinea",
+    "code": "PG"
+  },
+  {
+    "name": "Paraguay",
+    "code": "PY"
+  },
+  {
+    "name": "Peru",
+    "code": "PE"
+  },
+  {
+    "name": "Philippines",
+    "code": "PH"
+  },
+  {
+    "name": "Pitcairn",
+    "code": "PN"
+  },
+  {
+    "name": "Poland",
+    "code": "PL"
+  },
+  {
+    "name": "Portugal",
+    "code": "PT"
+  },
+  {
+    "name": "Puerto Rico",
+    "code": "PR"
+  },
+  {
+    "name": "Qatar",
+    "code": "QA"
+  },
+  {
+    "name": "Réunion",
+    "code": "RE"
+  },
+  {
+    "name": "Romania",
+    "code": "RO"
+  },
+  {
+    "name": "Russian Federation",
+    "code": "RU"
+  },
+  {
+    "name": "Rwanda",
+    "code": "RW"
+  },
+  {
+    "name": "Saint Barthélemy",
+    "code": "BL"
+  },
+  {
+    "name": "Saint Helena, Ascension and Tristan da Cunha",
+    "code": "SH"
+  },
+  {
+    "name": "Saint Kitts and Nevis",
+    "code": "KN"
+  },
+  {
+    "name": "Saint Lucia",
+    "code": "LC"
+  },
+  {
+    "name": "Saint Martin (French part)",
+    "code": "MF"
+  },
+  {
+    "name": "Saint Pierre and Miquelon",
+    "code": "PM"
+  },
+  {
+    "name": "Saint Vincent and the Grenadines",
+    "code": "VC"
+  },
+  {
+    "name": "Samoa",
+    "code": "WS"
+  },
+  {
+    "name": "San Marino",
+    "code": "SM"
+  },
+  {
+    "name": "Sao Tome and Principe",
+    "code": "ST"
+  },
+  {
+    "name": "Saudi Arabia",
+    "code": "SA"
+  },
+  {
+    "name": "Senegal",
+    "code": "SN"
+  },
+  {
+    "name": "Serbia",
+    "code": "RS"
+  },
+  {
+    "name": "Seychelles",
+    "code": "SC"
+  },
+  {
+    "name": "Sierra Leone",
+    "code": "SL"
+  },
+  {
+    "name": "Singapore",
+    "code": "SG"
+  },
+  {
+    "name": "Sint Maarten (Dutch part)",
+    "code": "SX"
+  },
+  {
+    "name": "Slovakia",
+    "code": "SK"
+  },
+  {
+    "name": "Slovenia",
+    "code": "SI"
+  },
+  {
+    "name": "Solomon Islands",
+    "code": "SB"
+  },
+  {
+    "name": "Somalia",
+    "code": "SO"
+  },
+  {
+    "name": "South Africa",
+    "code": "ZA"
+  },
+  {
+    "name": "South Georgia and the South Sandwich Islands",
+    "code": "GS"
+  },
+  {
+    "name": "South Sudan",
+    "code": "SS"
+  },
+  {
+    "name": "Spain",
+    "code": "ES"
+  },
+  {
+    "name": "Sri Lanka",
+    "code": "LK"
+  },
+  {
+    "name": "Sudan",
+    "code": "SD"
+  },
+  {
+    "name": "Suriname",
+    "code": "SR"
+  },
+  {
+    "name": "Svalbard and Jan Mayen",
+    "code": "SJ"
+  },
+  {
+    "name": "Eswatini",
+    "code": "SZ"
+  },
+  {
+    "name": "Sweden",
+    "code": "SE"
+  },
+  {
+    "name": "Switzerland",
+    "code": "CH"
+  },
+  {
+    "name": "Syrian Arab Republic",
+    "code": "SY"
+  },
+  {
+    "name": "Taiwan, Province of China",
+    "code": "TW"
+  },
+  {
+    "name": "Tajikistan",
+    "code": "TJ"
+  },
+  {
+    "name": "Tanzania, United Republic of",
+    "code": "TZ"
+  },
+  {
+    "name": "Thailand",
+    "code": "TH"
+  },
+  {
+    "name": "Timor-Leste",
+    "code": "TL"
+  },
+  {
+    "name": "Togo",
+    "code": "TG"
+  },
+  {
+    "name": "Tokelau",
+    "code": "TK"
+  },
+  {
+    "name": "Tonga",
+    "code": "TO"
+  },
+  {
+    "name": "Trinidad and Tobago",
+    "code": "TT"
+  },
+  {
+    "name": "Tunisia",
+    "code": "TN"
+  },
+  {
+    "name": "Turkey",
+    "code": "TR"
+  },
+  {
+    "name": "Turkmenistan",
+    "code": "TM"
+  },
+  {
+    "name": "Turks and Caicos Islands",
+    "code": "TC"
+  },
+  {
+    "name": "Tuvalu",
+    "code": "TV"
+  },
+  {
+    "name": "Uganda",
+    "code": "UG"
+  },
+  {
+    "name": "Ukraine",
+    "code": "UA"
+  },
+  {
+    "name": "United Arab Emirates",
+    "code": "AE"
+  },
+  {
+    "name": "United Kingdom",
+    "code": "GB"
+  },
+  {
+    "name": "United States",
+    "code": "US"
+  },
+  {
+    "name": "United States Minor Outlying Islands",
+    "code": "UM"
+  },
+  {
+    "name": "Uruguay",
+    "code": "UY"
+  },
+  {
+    "name": "Uzbekistan",
+    "code": "UZ"
+  },
+  {
+    "name": "Vanuatu",
+    "code": "VU"
+  },
+  {
+    "name": "Venezuela, Bolivarian Republic of",
+    "code": "VE"
+  },
+  {
+    "name": "Viet Nam",
+    "code": "VN"
+  },
+  {
+    "name": "Virgin Islands, British",
+    "code": "VG"
+  },
+  {
+    "name": "Virgin Islands, U.S.",
+    "code": "VI"
+  },
+  {
+    "name": "Wallis and Futuna",
+    "code": "WF"
+  },
+  {
+    "name": "Western Sahara",
+    "code": "EH"
+  },
+  {
+    "name": "Yemen",
+    "code": "YE"
+  },
+  {
+    "name": "Zambia",
+    "code": "ZM"
+  },
+  {
+    "name": "Zimbabwe",
+    "code": "ZW"
+  }
+]

--- a/virtual_labs/tests/bookmarks/conftest.py
+++ b/virtual_labs/tests/bookmarks/conftest.py
@@ -1,8 +1,11 @@
 from typing import AsyncGenerator
 from uuid import uuid4
 
+import pytest
 import pytest_asyncio
 from httpx import AsyncClient, Response
+
+pytestmark = pytest.mark.skip(reason="Bookmarks are deprecated")
 
 
 @pytest_asyncio.fixture

--- a/virtual_labs/tests/test_config.py
+++ b/virtual_labs/tests/test_config.py
@@ -1,0 +1,106 @@
+import json
+from http import HTTPStatus
+
+import pytest
+from httpx import AsyncClient
+
+
+class TestGetCountries:
+    """Test cases for GET /config/countries endpoint."""
+
+    @pytest.mark.asyncio
+    async def test_returns_200(
+        self,
+        async_test_client: AsyncClient,
+    ) -> None:
+        """The countries endpoint should return 200."""
+        response = await async_test_client.get("/config/countries")
+        assert response.status_code == HTTPStatus.OK
+
+    @pytest.mark.asyncio
+    async def test_returns_json_content_type(
+        self,
+        async_test_client: AsyncClient,
+    ) -> None:
+        """Response should have application/json content type."""
+        response = await async_test_client.get("/config/countries")
+        assert "application/json" in response.headers.get("content-type", "")
+
+    @pytest.mark.asyncio
+    async def test_returns_list_of_countries(
+        self,
+        async_test_client: AsyncClient,
+    ) -> None:
+        """Response body should be a non-empty list."""
+        response = await async_test_client.get("/config/countries")
+        data = response.json()
+        assert isinstance(data, list)
+        assert len(data) > 0
+
+    @pytest.mark.asyncio
+    async def test_each_country_has_name_and_code(
+        self,
+        async_test_client: AsyncClient,
+    ) -> None:
+        """Every entry should have 'name' and 'code' keys."""
+        response = await async_test_client.get("/config/countries")
+        data = response.json()
+
+        for entry in data:
+            assert "name" in entry, f"Missing 'name' in {entry}"
+            assert "code" in entry, f"Missing 'code' in {entry}"
+
+    @pytest.mark.asyncio
+    async def test_country_codes_are_two_letter_uppercase(
+        self,
+        async_test_client: AsyncClient,
+    ) -> None:
+        """Country codes should be ISO 3166-1 alpha-2 (2 uppercase letters)."""
+        response = await async_test_client.get("/config/countries")
+        data = response.json()
+
+        for entry in data:
+            code = entry["code"]
+            assert len(code) == 2, f"Code '{code}' is not 2 characters"
+            assert code == code.upper(), f"Code '{code}' is not uppercase"
+            assert code.isalpha(), f"Code '{code}' is not alphabetic"
+
+    @pytest.mark.asyncio
+    async def test_known_countries_present(
+        self,
+        async_test_client: AsyncClient,
+    ) -> None:
+        """Spot-check that well-known countries are in the list."""
+        response = await async_test_client.get("/config/countries")
+        data = response.json()
+        codes = {entry["code"] for entry in data}
+
+        for expected in ("US", "GB", "DE", "JP", "CH"):
+            assert expected in codes, f"Expected country code {expected} not found"
+
+    @pytest.mark.asyncio
+    async def test_no_duplicate_codes(
+        self,
+        async_test_client: AsyncClient,
+    ) -> None:
+        """Country codes should be unique."""
+        response = await async_test_client.get("/config/countries")
+        data = response.json()
+        codes = [entry["code"] for entry in data]
+        assert len(codes) == len(set(codes)), "Duplicate country codes found"
+
+    @pytest.mark.asyncio
+    async def test_matches_static_file(
+        self,
+        async_test_client: AsyncClient,
+    ) -> None:
+        """The endpoint response should match the static country.json file."""
+        from pathlib import Path
+
+        static_path = Path(__file__).resolve().parent.parent / "static" / "country.json"
+        expected = json.loads(static_path.read_text(encoding="utf-8"))
+
+        response = await async_test_client.get("/config/countries")
+        actual = response.json()
+
+        assert actual == expected

--- a/virtual_labs/tests/users/test_check_email_availability.py
+++ b/virtual_labs/tests/users/test_check_email_availability.py
@@ -1,0 +1,158 @@
+from http import HTTPStatus
+
+import pytest
+from httpx import AsyncClient
+
+from virtual_labs.tests.utils import get_headers
+
+ENDPOINT = "/users/profile/email/_check"
+
+
+class TestCheckEmailAvailability:
+    """Test cases for GET /users/profile/email/_check endpoint."""
+
+    @pytest.mark.asyncio
+    async def test_available_email_returns_204(
+        self,
+        async_test_client: AsyncClient,
+    ) -> None:
+        """An email that nobody owns should return 204."""
+        client = async_test_client
+        headers = get_headers()
+
+        response = await client.get(
+            ENDPOINT,
+            params={"email": "completely-unique-unused@example.com"},
+            headers=headers,
+        )
+
+        assert response.status_code == HTTPStatus.NO_CONTENT
+
+    @pytest.mark.asyncio
+    async def test_own_email_returns_204(
+        self,
+        async_test_client: AsyncClient,
+    ) -> None:
+        """The caller's own current email should be considered available."""
+        client = async_test_client
+        headers = get_headers()
+
+        # fetch the caller's current email from their profile
+        profile_response = await client.get("/users/profile", headers=headers)
+        assert profile_response.status_code == HTTPStatus.OK
+        own_email = profile_response.json()["data"]["profile"]["email"]
+
+        response = await client.get(
+            ENDPOINT,
+            params={"email": own_email},
+            headers=headers,
+        )
+
+        assert response.status_code == HTTPStatus.NO_CONTENT
+
+    @pytest.mark.asyncio
+    async def test_taken_email_returns_422(
+        self,
+        async_test_client: AsyncClient,
+    ) -> None:
+        """An email owned by a different user should return 422."""
+        client = async_test_client
+        headers_user_test = get_headers("test")
+        headers_user_test1 = get_headers("test-1")
+
+        # get test-1's email
+        profile_response = await client.get(
+            "/users/profile", headers=headers_user_test1
+        )
+        assert profile_response.status_code == HTTPStatus.OK
+        other_user_email = profile_response.json()["data"]["profile"]["email"]
+
+        # check availability from user "test", should be taken
+        response = await client.get(
+            ENDPOINT,
+            params={"email": other_user_email},
+            headers=headers_user_test,
+        )
+
+        assert response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
+        body = response.json()
+        assert "not available" in body["message"].lower()
+
+    @pytest.mark.asyncio
+    async def test_invalid_email_returns_422(
+        self,
+        async_test_client: AsyncClient,
+    ) -> None:
+        """A malformed email should be rejected by Pydantic validation."""
+        client = async_test_client
+        headers = get_headers()
+
+        response = await client.get(
+            ENDPOINT,
+            params={"email": "not-an-email"},
+            headers=headers,
+        )
+
+        assert response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
+
+    @pytest.mark.asyncio
+    async def test_missing_email_param_returns_422(
+        self,
+        async_test_client: AsyncClient,
+    ) -> None:
+        """Omitting the email query param should return a validation error."""
+        client = async_test_client
+        headers = get_headers()
+
+        response = await client.get(
+            ENDPOINT,
+            headers=headers,
+        )
+
+        assert response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
+
+    @pytest.mark.asyncio
+    async def test_unauthenticated_request_returns_401(
+        self,
+        async_test_client: AsyncClient,
+    ) -> None:
+        """A request without a valid token should be rejected."""
+        client = async_test_client
+
+        response = await client.get(
+            ENDPOINT,
+            params={"email": "someone@example.com"},
+            headers={"Authorization": "Bearer invalid-token"},
+        )
+
+        assert response.status_code in (
+            HTTPStatus.UNAUTHORIZED,
+            HTTPStatus.FORBIDDEN,
+        )
+
+    @pytest.mark.asyncio
+    async def test_response_does_not_leak_user_info(
+        self,
+        async_test_client: AsyncClient,
+    ) -> None:
+        """The 422 response should not contain any user details."""
+        client = async_test_client
+        headers_test = get_headers("test")
+        headers_test1 = get_headers("test-1")
+
+        # get test-1's email
+        profile_response = await client.get("/users/profile", headers=headers_test1)
+        other_email = profile_response.json()["data"]["profile"]["email"]
+
+        response = await client.get(
+            ENDPOINT,
+            params={"email": other_email},
+            headers=headers_test,
+        )
+
+        assert response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
+        body = response.json()
+        # should not contain any user id, username, or the email itself
+        body_str = str(body).lower()
+        assert "test-1" not in body_str
+        assert other_email.lower() not in body.get("message", "").lower()

--- a/virtual_labs/tests/users/test_user_profile.py
+++ b/virtual_labs/tests/users/test_user_profile.py
@@ -1,0 +1,192 @@
+from http import HTTPStatus
+
+import pytest
+from httpx import AsyncClient
+
+
+class TestGetUserProfile:
+    """Test cases for GET /users/profile endpoint."""
+
+    @pytest.mark.asyncio
+    async def test_get_profile_returns_user_info(
+        self, async_test_client: AsyncClient
+    ) -> None:
+        client = async_test_client
+        response = await client.get("/users/profile")
+        assert response.status_code == HTTPStatus.OK
+        profile = response.json()["data"]["profile"]
+        assert "id" in profile
+        assert "email" in profile
+        assert "preferred_username" in profile
+        assert "first_name" in profile
+        assert "last_name" in profile
+        assert "email_verified" in profile
+        assert "address" in profile
+        assert "full_name" in profile
+
+    @pytest.mark.asyncio
+    async def test_get_profile_address_has_expected_fields(
+        self, async_test_client: AsyncClient
+    ) -> None:
+        client = async_test_client
+        response = await client.get("/users/profile")
+        assert response.status_code == HTTPStatus.OK
+        address = response.json()["data"]["profile"]["address"]
+        for field in ("street", "postal_code", "locality", "region", "country"):
+            assert field in address
+
+    @pytest.mark.asyncio
+    async def test_get_profile_without_auth_fails(
+        self, async_test_client: AsyncClient
+    ) -> None:
+        client = async_test_client
+        response = await client.get("/users/profile", headers={"Authorization": ""})
+        assert response.status_code != HTTPStatus.OK
+
+
+class TestUpdateUserProfile:
+    """Test cases for PATCH /users/profile endpoint."""
+
+    @pytest.mark.asyncio
+    async def test_update_profile_with_required_fields_only(
+        self, async_test_client: AsyncClient
+    ) -> None:
+        client = async_test_client
+        payload = {"email": "test@test.com", "country": "Switzerland"}
+        response = await client.patch("/users/profile", json=payload)
+        assert response.status_code == HTTPStatus.OK
+        assert response.json()["data"]["profile"]["email"] == "test@test.com"
+
+    @pytest.mark.asyncio
+    async def test_update_profile_with_all_fields(
+        self, async_test_client: AsyncClient
+    ) -> None:
+        client = async_test_client
+        payload = {
+            "email": "test@test.com",
+            "country": "Switzerland",
+            "first_name": "Updated",
+            "last_name": "User",
+            "address": {
+                "street": "123 Main St",
+                "postal_code": "1000",
+                "locality": "Lausanne",
+                "region": "Vaud",
+            },
+        }
+        response = await client.patch("/users/profile", json=payload)
+        assert response.status_code == HTTPStatus.OK
+        profile = response.json()["data"]["profile"]
+        assert profile["first_name"] == "Updated"
+        assert profile["last_name"] == "User"
+
+    @pytest.mark.asyncio
+    async def test_update_profile_persists_address(
+        self, async_test_client: AsyncClient
+    ) -> None:
+        client = async_test_client
+        payload = {
+            "email": "test@test.com",
+            "country": "France",
+            "address": {
+                "street": "10 Rue de Rivoli",
+                "postal_code": "75001",
+                "locality": "Paris",
+                "region": "Ile-de-France",
+            },
+        }
+        response = await client.patch("/users/profile", json=payload)
+        assert response.status_code == HTTPStatus.OK
+        address = response.json()["data"]["profile"]["address"]
+        assert address["country"] == "France"
+        assert address["street"] == "10 Rue de Rivoli"
+        assert address["postal_code"] == "75001"
+        assert address["locality"] == "Paris"
+        assert address["region"] == "Ile-de-France"
+
+    @pytest.mark.asyncio
+    async def test_update_profile_without_email_fails(
+        self, async_test_client: AsyncClient
+    ) -> None:
+        client = async_test_client
+        payload = {"country": "Switzerland", "first_name": "Test"}
+        response = await client.patch("/users/profile", json=payload)
+        assert response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
+
+    @pytest.mark.asyncio
+    async def test_update_profile_without_country_fails(
+        self, async_test_client: AsyncClient
+    ) -> None:
+        client = async_test_client
+        payload = {"email": "test@test.com", "first_name": "Test"}
+        response = await client.patch("/users/profile", json=payload)
+        assert response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
+
+    @pytest.mark.asyncio
+    async def test_update_profile_with_invalid_email_fails(
+        self, async_test_client: AsyncClient
+    ) -> None:
+        client = async_test_client
+        payload = {"email": "not-an-email", "country": "Switzerland"}
+        response = await client.patch("/users/profile", json=payload)
+        assert response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
+
+    @pytest.mark.asyncio
+    async def test_update_profile_with_empty_payload_fails(
+        self, async_test_client: AsyncClient
+    ) -> None:
+        client = async_test_client
+        response = await client.patch("/users/profile", json={})
+        assert response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
+
+    @pytest.mark.asyncio
+    async def test_update_profile_without_auth_fails(
+        self, async_test_client: AsyncClient
+    ) -> None:
+        client = async_test_client
+        payload = {"email": "test@test.com", "country": "Switzerland"}
+        response = await client.patch(
+            "/users/profile", json=payload, headers={"Authorization": ""}
+        )
+        assert response.status_code != HTTPStatus.OK
+
+    @pytest.mark.asyncio
+    async def test_update_profile_duplicate_email_returns_conflict(
+        self, async_test_client: AsyncClient
+    ) -> None:
+        client = async_test_client
+        payload = {"email": "test-1@test.com", "country": "Switzerland"}
+        response = await client.patch("/users/profile", json=payload)
+        assert response.status_code == HTTPStatus.CONFLICT
+        assert (
+            response.json()["message"]
+            == "This email address cannot be used. Try another one or sign in if you already have an account."
+        )
+        # Restore original email
+        await client.patch(
+            "/users/profile",
+            json={"email": "test@test.com", "country": "Switzerland"},
+        )
+
+    @pytest.mark.asyncio
+    async def test_update_profile_country_without_address_object(
+        self, async_test_client: AsyncClient
+    ) -> None:
+        client = async_test_client
+        payload = {"email": "test@test.com", "country": "Germany"}
+        response = await client.patch("/users/profile", json=payload)
+        assert response.status_code == HTTPStatus.OK
+        address = response.json()["data"]["profile"]["address"]
+        assert address["country"] == "Germany"
+
+    @pytest.mark.asyncio
+    async def test_update_profile_missing_country_with_address_fails(
+        self, async_test_client: AsyncClient
+    ) -> None:
+        client = async_test_client
+        payload = {
+            "email": "test@test.com",
+            "address": {"street": "123 Main St", "locality": "Lausanne"},
+        }
+        response = await client.patch("/users/profile", json=payload)
+        assert response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY

--- a/virtual_labs/tests/users/test_user_profile.py
+++ b/virtual_labs/tests/users/test_user_profile.py
@@ -160,9 +160,9 @@ class TestUpdateUserProfile:
         assert response.status_code == HTTPStatus.CONFLICT
         assert (
             response.json()["message"]
-            == "This email address cannot be used. Try another one or sign in if you already have an account."
+            == "We’re unable to update your profile with this email address. Please make sure the email is correct or try another one."
         )
-        # Restore original email
+        # restore original email
         await client.patch(
             "/users/profile",
             json={"email": "test@test.com", "country": "Switzerland"},
@@ -190,3 +190,99 @@ class TestUpdateUserProfile:
         }
         response = await client.patch("/users/profile", json=payload)
         assert response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
+
+
+class TestOnboardingUpdateUserProfile:
+    """Test cases for PATCH /users/onboarding/profile endpoint."""
+
+    @pytest.mark.asyncio
+    async def test_onboarding_update_first_and_last_name(
+        self, async_test_client: AsyncClient
+    ) -> None:
+        client = async_test_client
+        payload = {"first_name": "Onboard", "last_name": "User"}
+        response = await client.patch("/users/onboarding/profile", json=payload)
+        assert response.status_code == HTTPStatus.OK
+        profile = response.json()["data"]["profile"]
+        assert profile["first_name"] == "Onboard"
+        assert profile["last_name"] == "User"
+
+    @pytest.mark.asyncio
+    async def test_onboarding_update_country(
+        self, async_test_client: AsyncClient
+    ) -> None:
+        client = async_test_client
+        payload = {"country": "Algeria"}
+        response = await client.patch("/users/onboarding/profile", json=payload)
+        assert response.status_code == HTTPStatus.OK
+        address = response.json()["data"]["profile"]["address"]
+        assert address["country"] == "Algeria"
+
+    @pytest.mark.asyncio
+    async def test_onboarding_update_all_fields(
+        self, async_test_client: AsyncClient
+    ) -> None:
+        client = async_test_client
+        payload = {
+            "first_name": "New",
+            "last_name": "Name",
+            "country": "Switzerland",
+        }
+        response = await client.patch("/users/onboarding/profile", json=payload)
+        assert response.status_code == HTTPStatus.OK
+        profile = response.json()["data"]["profile"]
+        assert profile["first_name"] == "New"
+        assert profile["last_name"] == "Name"
+        assert profile["address"]["country"] == "Switzerland"
+
+    @pytest.mark.asyncio
+    async def test_onboarding_update_empty_payload_succeeds(
+        self, async_test_client: AsyncClient
+    ) -> None:
+        """Empty payload is valid since all fields are optional."""
+        client = async_test_client
+        response = await client.patch("/users/onboarding/profile", json={})
+        assert response.status_code == HTTPStatus.OK
+
+    @pytest.mark.asyncio
+    async def test_onboarding_does_not_change_email(
+        self, async_test_client: AsyncClient
+    ) -> None:
+        """Onboarding endpoint should preserve the existing email."""
+        client = async_test_client
+
+        # get current email
+        get_resp = await client.get("/users/profile")
+        original_email = get_resp.json()["data"]["profile"]["email"]
+
+        # update name via onboarding
+        await client.patch(
+            "/users/onboarding/profile",
+            json={"first_name": "Keep", "last_name": "Email"},
+        )
+
+        # verify email unchanged
+        get_resp = await client.get("/users/profile")
+        assert get_resp.json()["data"]["profile"]["email"] == original_email
+
+    @pytest.mark.asyncio
+    async def test_onboarding_update_without_auth_fails(
+        self, async_test_client: AsyncClient
+    ) -> None:
+        client = async_test_client
+        response = await client.patch(
+            "/users/onboarding/profile",
+            json={"first_name": "Test"},
+            headers={"Authorization": ""},
+        )
+        assert response.status_code != HTTPStatus.OK
+
+    @pytest.mark.asyncio
+    async def test_onboarding_update_only_first_name(
+        self, async_test_client: AsyncClient
+    ) -> None:
+        client = async_test_client
+        payload = {"first_name": "Solo"}
+        response = await client.patch("/users/onboarding/profile", json=payload)
+        assert response.status_code == HTTPStatus.OK
+        assert response.json()["data"]["profile"]["first_name"] == "Solo"

--- a/virtual_labs/tests/users/test_user_profile.py
+++ b/virtual_labs/tests/users/test_user_profile.py
@@ -52,7 +52,12 @@ class TestUpdateUserProfile:
         self, async_test_client: AsyncClient
     ) -> None:
         client = async_test_client
-        payload = {"email": "test@test.com", "country": "Switzerland"}
+        payload = {
+            "email": "test@test.com",
+            "country": "CH",
+            "first_name": "Test",
+            "last_name": "User",
+        }
         response = await client.patch("/users/profile", json=payload)
         assert response.status_code == HTTPStatus.OK
         assert response.json()["data"]["profile"]["email"] == "test@test.com"
@@ -64,7 +69,7 @@ class TestUpdateUserProfile:
         client = async_test_client
         payload = {
             "email": "test@test.com",
-            "country": "Switzerland",
+            "country": "CH",
             "first_name": "Updated",
             "last_name": "User",
             "address": {
@@ -87,7 +92,9 @@ class TestUpdateUserProfile:
         client = async_test_client
         payload = {
             "email": "test@test.com",
-            "country": "France",
+            "country": "FR",
+            "first_name": "Test",
+            "last_name": "User",
             "address": {
                 "street": "10 Rue de Rivoli",
                 "postal_code": "75001",
@@ -98,7 +105,7 @@ class TestUpdateUserProfile:
         response = await client.patch("/users/profile", json=payload)
         assert response.status_code == HTTPStatus.OK
         address = response.json()["data"]["profile"]["address"]
-        assert address["country"] == "France"
+        assert address["country"] == "FR"
         assert address["street"] == "10 Rue de Rivoli"
         assert address["postal_code"] == "75001"
         assert address["locality"] == "Paris"
@@ -109,7 +116,7 @@ class TestUpdateUserProfile:
         self, async_test_client: AsyncClient
     ) -> None:
         client = async_test_client
-        payload = {"country": "Switzerland", "first_name": "Test"}
+        payload = {"country": "CH", "first_name": "Test", "last_name": "User"}
         response = await client.patch("/users/profile", json=payload)
         assert response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
 
@@ -118,7 +125,7 @@ class TestUpdateUserProfile:
         self, async_test_client: AsyncClient
     ) -> None:
         client = async_test_client
-        payload = {"email": "test@test.com", "first_name": "Test"}
+        payload = {"email": "test@test.com", "first_name": "Test", "last_name": "User"}
         response = await client.patch("/users/profile", json=payload)
         assert response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
 
@@ -127,7 +134,12 @@ class TestUpdateUserProfile:
         self, async_test_client: AsyncClient
     ) -> None:
         client = async_test_client
-        payload = {"email": "not-an-email", "country": "Switzerland"}
+        payload = {
+            "email": "not-an-email",
+            "country": "CH",
+            "first_name": "Test",
+            "last_name": "User",
+        }
         response = await client.patch("/users/profile", json=payload)
         assert response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
 
@@ -144,7 +156,12 @@ class TestUpdateUserProfile:
         self, async_test_client: AsyncClient
     ) -> None:
         client = async_test_client
-        payload = {"email": "test@test.com", "country": "Switzerland"}
+        payload = {
+            "email": "test@test.com",
+            "country": "CH",
+            "first_name": "Test",
+            "last_name": "User",
+        }
         response = await client.patch(
             "/users/profile", json=payload, headers={"Authorization": ""}
         )
@@ -155,7 +172,12 @@ class TestUpdateUserProfile:
         self, async_test_client: AsyncClient
     ) -> None:
         client = async_test_client
-        payload = {"email": "test-1@test.com", "country": "Switzerland"}
+        payload = {
+            "email": "test-1@test.com",
+            "country": "CH",
+            "first_name": "Test",
+            "last_name": "User",
+        }
         response = await client.patch("/users/profile", json=payload)
         assert response.status_code == HTTPStatus.CONFLICT
         assert (
@@ -165,7 +187,12 @@ class TestUpdateUserProfile:
         # restore original email
         await client.patch(
             "/users/profile",
-            json={"email": "test@test.com", "country": "Switzerland"},
+            json={
+                "email": "test@test.com",
+                "country": "CH",
+                "first_name": "Test",
+                "last_name": "User",
+            },
         )
 
     @pytest.mark.asyncio
@@ -173,11 +200,16 @@ class TestUpdateUserProfile:
         self, async_test_client: AsyncClient
     ) -> None:
         client = async_test_client
-        payload = {"email": "test@test.com", "country": "Germany"}
+        payload = {
+            "email": "test@test.com",
+            "country": "DE",
+            "first_name": "Test",
+            "last_name": "User",
+        }
         response = await client.patch("/users/profile", json=payload)
         assert response.status_code == HTTPStatus.OK
         address = response.json()["data"]["profile"]["address"]
-        assert address["country"] == "Germany"
+        assert address["country"] == "DE"
 
     @pytest.mark.asyncio
     async def test_update_profile_missing_country_with_address_fails(
@@ -200,7 +232,12 @@ class TestOnboardingUpdateUserProfile:
         self, async_test_client: AsyncClient
     ) -> None:
         client = async_test_client
-        payload = {"first_name": "Onboard", "last_name": "User"}
+        payload = {
+            "email": "test@test.com",
+            "country": "CH",
+            "first_name": "Onboard",
+            "last_name": "User",
+        }
         response = await client.patch("/users/onboarding/profile", json=payload)
         assert response.status_code == HTTPStatus.OK
         profile = response.json()["data"]["profile"]
@@ -212,11 +249,16 @@ class TestOnboardingUpdateUserProfile:
         self, async_test_client: AsyncClient
     ) -> None:
         client = async_test_client
-        payload = {"country": "Algeria"}
+        payload = {
+            "email": "test@test.com",
+            "country": "DZ",
+            "first_name": "Test",
+            "last_name": "User",
+        }
         response = await client.patch("/users/onboarding/profile", json=payload)
         assert response.status_code == HTTPStatus.OK
         address = response.json()["data"]["profile"]["address"]
-        assert address["country"] == "Algeria"
+        assert address["country"] == "DZ"
 
     @pytest.mark.asyncio
     async def test_onboarding_update_all_fields(
@@ -224,46 +266,47 @@ class TestOnboardingUpdateUserProfile:
     ) -> None:
         client = async_test_client
         payload = {
+            "email": "test@test.com",
+            "country": "CH",
             "first_name": "New",
             "last_name": "Name",
-            "country": "Switzerland",
         }
         response = await client.patch("/users/onboarding/profile", json=payload)
         assert response.status_code == HTTPStatus.OK
         profile = response.json()["data"]["profile"]
         assert profile["first_name"] == "New"
         assert profile["last_name"] == "Name"
-        assert profile["address"]["country"] == "Switzerland"
+        assert profile["address"]["country"] == "CH"
 
     @pytest.mark.asyncio
-    async def test_onboarding_update_empty_payload_succeeds(
+    async def test_onboarding_update_empty_payload_fails(
         self, async_test_client: AsyncClient
     ) -> None:
-        """Empty payload is valid since all fields are optional."""
+        """Empty payload should fail since all fields are required."""
         client = async_test_client
         response = await client.patch("/users/onboarding/profile", json={})
-        assert response.status_code == HTTPStatus.OK
+        assert response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
 
     @pytest.mark.asyncio
     async def test_onboarding_does_not_change_email(
         self, async_test_client: AsyncClient
     ) -> None:
-        """Onboarding endpoint should preserve the existing email."""
+        """Onboarding endpoint updates email to the provided value."""
         client = async_test_client
 
-        # get current email
-        get_resp = await client.get("/users/profile")
-        original_email = get_resp.json()["data"]["profile"]["email"]
+        # update via onboarding with same email
+        payload = {
+            "email": "test@test.com",
+            "country": "CH",
+            "first_name": "Keep",
+            "last_name": "Email",
+        }
+        response = await client.patch("/users/onboarding/profile", json=payload)
+        assert response.status_code == HTTPStatus.OK
 
-        # update name via onboarding
-        await client.patch(
-            "/users/onboarding/profile",
-            json={"first_name": "Keep", "last_name": "Email"},
-        )
-
-        # verify email unchanged
+        # verify email is what we set
         get_resp = await client.get("/users/profile")
-        assert get_resp.json()["data"]["profile"]["email"] == original_email
+        assert get_resp.json()["data"]["profile"]["email"] == "test@test.com"
 
     @pytest.mark.asyncio
     async def test_onboarding_update_without_auth_fails(
@@ -272,17 +315,22 @@ class TestOnboardingUpdateUserProfile:
         client = async_test_client
         response = await client.patch(
             "/users/onboarding/profile",
-            json={"first_name": "Test"},
+            json={
+                "email": "test@test.com",
+                "country": "CH",
+                "first_name": "Test",
+                "last_name": "User",
+            },
             headers={"Authorization": ""},
         )
         assert response.status_code != HTTPStatus.OK
 
     @pytest.mark.asyncio
-    async def test_onboarding_update_only_first_name(
+    async def test_onboarding_update_only_first_name_fails(
         self, async_test_client: AsyncClient
     ) -> None:
+        """Partial payload should fail since all fields are required."""
         client = async_test_client
         payload = {"first_name": "Solo"}
         response = await client.patch("/users/onboarding/profile", json=payload)
-        assert response.status_code == HTTPStatus.OK
-        assert response.json()["data"]["profile"]["first_name"] == "Solo"
+        assert response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY

--- a/virtual_labs/usecases/labs/create_virtual_lab.py
+++ b/virtual_labs/usecases/labs/create_virtual_lab.py
@@ -1,8 +1,8 @@
-from contextlib import contextmanager
+from contextlib import asynccontextmanager
 from datetime import timezone
 from decimal import Decimal
 from http import HTTPStatus
-from typing import Iterator, Literal, TypedDict
+from typing import AsyncIterator, Literal, TypedDict
 from uuid import UUID, uuid4
 
 from loguru import logger
@@ -187,7 +187,7 @@ async def create_virtual_lab(
             )
 
     # 4. Save lab to db
-    with handle_vlab_creation_errors(groups=groups, group_repo=group_repo):
+    async with handle_vlab_creation_errors(db=db, groups=groups, group_repo=group_repo):
         lab_with_ids = repository.VirtualLabDbCreate(
             id=new_lab_id,
             owner_id=owner_id,
@@ -245,6 +245,8 @@ async def create_virtual_lab(
         if user.get("email", owner_email) is not None:
             await send_welcome_email(owner_email)
 
+        await db.commit()
+
         created_lab = domain.CreateLabOut(
             virtual_lab=lab_details,
         )
@@ -275,7 +277,9 @@ async def create_course_vlab(
     if settings.ACCOUNTING_BASE_URL is not None:
         try:
             await accounting_cases.create_virtual_lab_account(
-                virtual_lab_id=new_lab_id, name=lab.name, balance=Decimal(0)
+                virtual_lab_id=new_lab_id,
+                name=lab.name,
+                balance=Decimal(0),
             )
 
         except Exception as ex:
@@ -297,7 +301,7 @@ async def create_course_vlab(
             )
 
     # Create lab in database
-    with handle_vlab_creation_errors(groups=groups, group_repo=group_repo):
+    async with handle_vlab_creation_errors(db=db, groups=groups, group_repo=group_repo):
         lab_with_ids = repository.VirtualLabDbCreate(
             id=new_lab_id,
             owner_id=user_id,
@@ -308,6 +312,9 @@ async def create_course_vlab(
 
         db_lab = await repository.create_virtual_lab(db, lab_with_ids)
         lab_details = domain.VirtualLabDetails.model_validate(db_lab)
+
+        await db.commit()
+
         created_lab = domain.CreateLabOut(
             virtual_lab=lab_details,
         )
@@ -328,13 +335,14 @@ def _cleanup_kc_groups(
         logger.error(f"Error cleaning up KC groups: {cleanup_error}")
 
 
-@contextmanager
-def handle_vlab_creation_errors(
-    groups: GroupIds, group_repo: GroupMutationRepository
-) -> Iterator[None]:
+@asynccontextmanager
+async def handle_vlab_creation_errors(
+    db: AsyncSession, groups: GroupIds, group_repo: GroupMutationRepository
+) -> AsyncIterator[None]:
     try:
         yield
     except IntegrityError as error:
+        await db.rollback()
         _cleanup_kc_groups(groups, group_repo, "database error")
         logger.error(f"Virtual lab could not be created due to database error {error}")
         raise VliError(
@@ -343,6 +351,7 @@ def handle_vlab_creation_errors(
             http_status_code=HTTPStatus.CONFLICT,
         )
     except SQLAlchemyError as error:
+        await db.rollback()
         _cleanup_kc_groups(groups, group_repo, "database error")
         logger.error(
             f"Virtual lab could not be created due to an unknown database error {error}"
@@ -353,9 +362,11 @@ def handle_vlab_creation_errors(
             http_status_code=HTTPStatus.BAD_REQUEST,
         )
     except VliError as error:
+        await db.rollback()
         _cleanup_kc_groups(groups, group_repo, "VLI error")
         raise error
     except Exception as error:
+        await db.rollback()
         _cleanup_kc_groups(groups, group_repo, "unknown error")
         logger.error(
             f"Virtual lab could not be created due to an unknown error {error}"

--- a/virtual_labs/usecases/users/__init__.py
+++ b/virtual_labs/usecases/users/__init__.py
@@ -9,7 +9,7 @@ from .onboarding import (
     update_user_onboarding_status,
 )
 from .set_recent_workspace import set_recent_workspace
-from .update_user_profile import update_user_profile
+from .update_user_profile import onboarding_update_user_profile, update_user_profile
 from .workspace_hierarchy_species import (
     get_workspace_hierarchy_species_preference,
     update_workspace_hierarchy_species_preference,
@@ -22,6 +22,7 @@ __all__ = [
     "get_user_profile",
     "set_recent_workspace",
     "update_user_profile",
+    "onboarding_update_user_profile",
     "get_user_onboarding_status",
     "update_user_onboarding_status",
     "reset_user_onboarding_status",

--- a/virtual_labs/usecases/users/__init__.py
+++ b/virtual_labs/usecases/users/__init__.py
@@ -1,3 +1,4 @@
+from .check_email_availability import check_email_availability
 from .get_all_user_groups import get_all_user_groups
 from .get_count_of_all_users import get_count_of_all_users
 from .get_recent_workspace import get_recent_workspace
@@ -20,6 +21,7 @@ __all__ = [
     "get_count_of_all_users",
     "get_recent_workspace",
     "get_user_profile",
+    "check_email_availability",
     "set_recent_workspace",
     "update_user_profile",
     "onboarding_update_user_profile",

--- a/virtual_labs/usecases/users/check_email_availability.py
+++ b/virtual_labs/usecases/users/check_email_availability.py
@@ -1,0 +1,52 @@
+from http import HTTPStatus
+from typing import Tuple
+
+from fastapi import Response
+from loguru import logger
+
+from virtual_labs.core.exceptions.api_error import VliError, VliErrorCode
+from virtual_labs.infrastructure.kc.models import AuthUser
+from virtual_labs.repositories.user_repo import UserQueryRepository
+from virtual_labs.shared.utils.auth import get_user_id_from_auth
+
+
+async def check_email_availability(
+    email: str,
+    auth: Tuple[AuthUser, str],
+) -> Response:
+    """
+    Check whether the given email can be used for a profile update.
+
+    Returns
+        - 204 if the email is available,
+    Raises
+        - 422 if already taken by another user.
+    """
+    try:
+        user_id = str(get_user_id_from_auth(auth))
+        user_repo = UserQueryRepository()
+
+        users = await user_repo.Kc.a_get_users({"email": email, "exact": "true"})
+
+        is_taken = False
+        if isinstance(users, list) and len(users) > 0:
+            # if the only match is the caller themselves, the email is still available
+            is_taken = not all(u.get("id") == user_id for u in users)
+
+        if is_taken:
+            raise VliError(
+                error_code=VliErrorCode.INVALID_REQUEST,
+                http_status_code=HTTPStatus.UNPROCESSABLE_ENTITY,
+                message="This email address is not available. Please try another one.",
+            )
+
+        return Response(status_code=HTTPStatus.NO_CONTENT)
+    except VliError:
+        raise
+    except Exception as e:
+        logger.exception(f"Error checking email availability: {str(e)}")
+        raise VliError(
+            error_code=VliErrorCode.INTERNAL_SERVER_ERROR,
+            http_status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
+            message="An error occurred while checking email availability",
+        )

--- a/virtual_labs/usecases/users/update_user_profile.py
+++ b/virtual_labs/usecases/users/update_user_profile.py
@@ -2,7 +2,7 @@ from http import HTTPStatus
 from typing import Any, Dict, Tuple, cast
 
 from fastapi import Response
-from keycloak import KeycloakError  # type: ignore[import-untyped]
+from keycloak import KeycloakError, KeycloakPutError  # type: ignore[import-untyped]
 from loguru import logger
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -32,7 +32,9 @@ from virtual_labs.shared.utils.auth import get_user_id_from_auth
 
 
 async def update_user_profile(
-    payload: UpdateUserProfileRequest, auth: Tuple[AuthUser, str], session: AsyncSession
+    payload: UpdateUserProfileRequest,
+    auth: Tuple[AuthUser, str],
+    session: AsyncSession,
 ) -> Response:
     """
     update the profile information for the authenticated user.
@@ -59,49 +61,53 @@ async def update_user_profile(
             raise EntityNotFound
 
         update_data: Dict[str, Any] = {}
-        # TODO:update user email from payload if does not exists
-        if payload.email is not None:
-            update_data["email"] = payload.email
-        else:
-            update_data["email"] = kc_user.get("email")
+        update_data["email"] = payload.email
         if payload.first_name is not None:
             update_data["firstName"] = payload.first_name
         if payload.last_name is not None:
             update_data["lastName"] = payload.last_name
 
-        if payload.address is not None:
-            attributes = getattr(kc_user, "attributes", {}) or {}
+        attributes = kc_user.get("attributes", {}) or {}
+        merged_attributes = {
+            k: v if isinstance(v, list) else [str(v)] for k, v in attributes.items()
+        }
 
+        merged_attributes["country"] = [payload.country]
+
+        if payload.address is not None:
             address_fields = {
                 "street": payload.address.street,
                 "postal_code": payload.address.postal_code,
                 "locality": payload.address.locality,
                 "region": payload.address.region,
-                "country": payload.address.country,
             }
 
             address_updates = {
                 k: [v] for k, v in address_fields.items() if v is not None
             }
-
-            merged_attributes = {
-                k: v if isinstance(v, list) else [str(v)] for k, v in attributes.items()
-            }
             merged_attributes.update(address_updates)
 
-            if merged_attributes:
-                update_data["attributes"] = merged_attributes
+        update_data["attributes"] = merged_attributes
 
         if update_data:
             await user_mutation_repo.Kc.a_update_user(
-                user_id=str(user_id), payload=update_data
+                user_id=str(user_id),
+                payload=update_data,
             )
 
             kc_user = cast(
                 Dict[str, Any], await user_query_repo.get_user_info(token=token)
             )
 
-        address_data = kc_user.get("address", {})
+        # Fetch user via admin API to get attributes (address fields)
+        kc_admin_user = await user_query_repo.get_user(user_id=str(user_id))
+        attributes = kc_admin_user.get("attributes", {}) if kc_admin_user else {}
+
+        def _attr(key: str) -> str:
+            val = attributes.get(key, "")
+            if isinstance(val, list):
+                return val[0] if val else ""
+            return str(val) if val else ""
 
         customer = await stripe_user_repo.get_by_user_id(
             user_id=user_id,
@@ -110,7 +116,7 @@ async def update_user_profile(
         if customer is None:
             stripe_customer = await stripe_service.create_customer(
                 user_id=user_id,
-                email=(payload.email if payload.email else kc_user.get("email")) or "",
+                email=payload.email,
                 name=f"{payload.first_name or kc_user.get('given_name')} {payload.last_name or kc_user.get('family_name')}",
             )
             if stripe_customer is None:
@@ -125,22 +131,22 @@ async def update_user_profile(
             stripe_customer = await stripe_service.update_customer(
                 customer_id=customer.stripe_customer_id,
                 name=f"{payload.first_name or kc_user.get('given_name')} {payload.last_name or kc_user.get('family_name')}",
-                email=payload.email if payload.email else kc_user.get("email"),
+                email=payload.email,
             )
 
         user_profile = UserProfile(
             id=user_id,
             preferred_username=kc_user["preferred_username"],
             email=kc_user["email"],
-            first_name=kc_user["given_name"] or "",
-            last_name=kc_user["family_name"] or "",
+            first_name=kc_user.get("given_name") or "",
+            last_name=kc_user.get("family_name") or "",
             email_verified=kc_user["email_verified"],
             address=Address(
-                street=address_data.get("street_address", ""),
-                postal_code=address_data.get("postal_code", ""),
-                locality=address_data.get("locality", ""),
-                region=address_data.get("region", ""),
-                country=address_data.get("country", ""),
+                street=_attr("street"),
+                postal_code=_attr("postal_code"),
+                locality=_attr("locality"),
+                region=_attr("region"),
+                country=_attr("country"),
             ),
         )
 
@@ -155,6 +161,25 @@ async def update_user_profile(
             http_status_code=HTTPStatus.NOT_FOUND,
             message="User not found",
         )
+    except KeycloakPutError as e:
+        logger.error(
+            f"Keycloak put error: {e.error_message} | {e.response_code} | {e.response_body}"
+        )
+        message = "An error occurred while updating the user profile"
+        if (
+            isinstance(e.response_body, bytes)
+            and b"User exists with same email" in e.response_body
+        ) or (
+            isinstance(e.response_body, str)
+            and "User exists with same email" in e.response_body
+        ):
+            message = "This email address cannot be used. Try another one or sign in if you already have an account."
+
+        raise VliError(
+            error_code=VliErrorCode.DATA_CONFLICT,
+            http_status_code=HTTPStatus.CONFLICT,
+            message=message,
+        ) from e
     except KeycloakError as e:
         logger.error(f"Keycloak error: {str(e)}")
         raise VliError(
@@ -162,7 +187,6 @@ async def update_user_profile(
             http_status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
             message=str(e) or "An error occurred while updating the user profile",
         ) from e
-
     except Exception as e:
         logger.exception(f"Error updating user profile: {str(e)}")
         raise VliError(

--- a/virtual_labs/usecases/users/update_user_profile.py
+++ b/virtual_labs/usecases/users/update_user_profile.py
@@ -104,10 +104,10 @@ async def _build_user_profile(
     return UserProfile(
         id=user_id,
         preferred_username=kc_user["preferred_username"],
-        email=kc_user["email"],
-        first_name=kc_user.get("given_name") or "",
-        last_name=kc_user.get("family_name") or "",
-        email_verified=kc_user["email_verified"],
+        email=kc_user.get("email", ""),
+        first_name=kc_user.get("given_name", ""),
+        last_name=kc_user.get("family_name", ""),
+        email_verified=kc_user.get("email_verified", True),
         address=Address(
             street=_attr("street"),
             postal_code=_attr("postal_code"),
@@ -146,12 +146,9 @@ async def update_user_profile(
         if not kc_user:
             raise EntityNotFound
 
-        # Build Keycloak update payload
-        update_data: Dict[str, Any] = {"email": payload.email}
-        if payload.first_name is not None:
-            update_data["firstName"] = payload.first_name
-        if payload.last_name is not None:
-            update_data["lastName"] = payload.last_name
+        update_data: Dict[str, Any] = {"email": payload.email, "emailVerified": True}
+        update_data["firstName"] = payload.first_name
+        update_data["lastName"] = payload.last_name
 
         attributes = kc_user.get("attributes", {}) or {}
         merged_attributes = {
@@ -185,7 +182,7 @@ async def update_user_profile(
         await _sync_stripe_customer(
             user_id=user_id,
             email=payload.email,
-            name=f"{payload.first_name or kc_user.get('given_name')} {payload.last_name or kc_user.get('family_name')}",
+            name=f"{payload.first_name} {payload.last_name}",
             stripe_user_repo=stripe_user_repo,
             stripe_service=stripe_service,
             stripe_user_mutation_repo=stripe_user_mutation_repo,
@@ -273,9 +270,9 @@ async def onboarding_update_user_profile(
         if not kc_user:
             raise EntityNotFound
 
-        # build Keycloak update payload with the provided email and country
         update_data: Dict[str, Any] = {
             "email": payload.email,
+            "emailVerified": True,
             "firstName": payload.first_name,
             "lastName": payload.last_name,
         }

--- a/virtual_labs/usecases/users/update_user_profile.py
+++ b/virtual_labs/usecases/users/update_user_profile.py
@@ -250,7 +250,8 @@ async def onboarding_update_user_profile(
 ) -> Response:
     """
     Update the profile information during onboarding.
-    Only allows updating first_name, last_name, and country.
+    Requires email, country, first_name, and last_name.
+    Stores them in both Keycloak and Stripe.
 
     Args:
         payload: The onboarding profile data to update
@@ -272,19 +273,18 @@ async def onboarding_update_user_profile(
         if not kc_user:
             raise EntityNotFound
 
-        # Build Keycloak update payload (email stays unchanged)
-        update_data: Dict[str, Any] = {"email": kc_user.get("email")}
-        if payload.first_name is not None:
-            update_data["firstName"] = payload.first_name
-        if payload.last_name is not None:
-            update_data["lastName"] = payload.last_name
+        # build Keycloak update payload with the provided email and country
+        update_data: Dict[str, Any] = {
+            "email": payload.email,
+            "firstName": payload.first_name,
+            "lastName": payload.last_name,
+        }
 
         attributes = kc_user.get("attributes", {}) or {}
         merged_attributes = {
             k: v if isinstance(v, list) else [str(v)] for k, v in attributes.items()
         }
-        if payload.country is not None:
-            merged_attributes["country"] = [payload.country]
+        merged_attributes["country"] = [payload.country]
 
         update_data["attributes"] = merged_attributes
 
@@ -302,16 +302,15 @@ async def onboarding_update_user_profile(
             user_query_repo=user_query_repo,
         )
 
-        # Sync Stripe customer name if first_name or last_name changed
-        if payload.first_name is not None or payload.last_name is not None:
-            await _sync_stripe_customer(
-                user_id=user_id,
-                email=kc_user["email"],
-                name=f"{user_profile.first_name} {user_profile.last_name}",
-                stripe_user_repo=stripe_user_repo,
-                stripe_service=stripe_service,
-                stripe_user_mutation_repo=stripe_user_mutation_repo,
-            )
+        # always sync Stripe with the provided email and current name
+        await _sync_stripe_customer(
+            user_id=user_id,
+            email=payload.email,
+            name=f"{user_profile.first_name} {user_profile.last_name}",
+            stripe_user_repo=stripe_user_repo,
+            stripe_service=stripe_service,
+            stripe_user_mutation_repo=stripe_user_mutation_repo,
+        )
 
         return VliResponse.new(
             message="User profile updated successfully",
@@ -324,6 +323,25 @@ async def onboarding_update_user_profile(
             http_status_code=HTTPStatus.NOT_FOUND,
             message="User not found",
         )
+    except KeycloakPutError as e:
+        logger.error(
+            f"Keycloak put error: {e.error_message} | {e.response_code} | {e.response_body}"
+        )
+        message = "An error occurred while updating the user profile"
+        if (
+            isinstance(e.response_body, bytes)
+            and b"User exists with same email" in e.response_body
+        ) or (
+            isinstance(e.response_body, str)
+            and "User exists with same email" in e.response_body
+        ):
+            message = "We're unable to update your profile with this email address. Please make sure the email is correct or try another one."
+
+        raise VliError(
+            error_code=VliErrorCode.DATA_CONFLICT,
+            http_status_code=HTTPStatus.CONFLICT,
+            message=message,
+        ) from e
     except KeycloakError as e:
         logger.error(f"Keycloak error: {str(e)}")
         raise VliError(

--- a/virtual_labs/usecases/users/update_user_profile.py
+++ b/virtual_labs/usecases/users/update_user_profile.py
@@ -4,6 +4,7 @@ from typing import Any, Dict, Tuple, cast
 from fastapi import Response
 from keycloak import KeycloakError, KeycloakPutError  # type: ignore[import-untyped]
 from loguru import logger
+from pydantic import UUID4
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from virtual_labs.core.exceptions.api_error import VliError, VliErrorCode
@@ -14,6 +15,7 @@ from virtual_labs.core.exceptions.generic_exceptions import (
 from virtual_labs.core.response.api_response import VliResponse
 from virtual_labs.domain.user import (
     Address,
+    OnboardingUpdateUserProfileRequest,
     UpdateUserProfileRequest,
     UserProfile,
     UserProfileResponse,
@@ -31,13 +33,98 @@ from virtual_labs.repositories.user_repo import (
 from virtual_labs.shared.utils.auth import get_user_id_from_auth
 
 
+async def _sync_stripe_customer(
+    *,
+    user_id: Any,
+    email: str,
+    name: str,
+    stripe_user_repo: StripeUserQueryRepository,
+    stripe_service: Any,
+    stripe_user_mutation_repo: StripeUserMutationRepository,
+) -> None:
+    """Create or update the Stripe customer with the given name and email."""
+    customer = await stripe_user_repo.get_by_user_id(user_id=user_id)
+
+    if customer is None:
+        stripe_customer = await stripe_service.create_customer(
+            user_id=user_id,
+            email=email,
+            name=name,
+        )
+        if stripe_customer is None:
+            raise EntityNotCreated("Stripe customer creation failed")
+
+        await stripe_user_mutation_repo.create(
+            user_id=user_id,
+            stripe_customer_id=stripe_customer.id,
+        )
+    elif customer.stripe_customer_id:
+        await stripe_service.update_customer(
+            customer_id=customer.stripe_customer_id,
+            name=name,
+            email=email,
+        )
+
+
+async def _apply_kc_update(
+    *,
+    user_id: UUID4,
+    token: str,
+    update_data: Dict[str, Any],
+    user_query_repo: UserQueryRepository,
+    user_mutation_repo: UserMutationRepository,
+) -> Dict[str, Any]:
+    """Push *update_data* to Keycloak and return the refreshed userinfo dict."""
+    await user_mutation_repo.Kc.a_update_user(
+        user_id=str(user_id),
+        payload=update_data,
+    )
+    return cast(
+        Dict[str, Any],
+        await user_query_repo.get_user_info(token=token),
+    )
+
+
+async def _build_user_profile(
+    *,
+    user_id: UUID4,
+    kc_user: Dict[str, Any],
+    user_query_repo: UserQueryRepository,
+) -> UserProfile:
+    """Fetch attributes from the admin API and build a UserProfile."""
+    kc_admin_user = await user_query_repo.get_user(user_id=str(user_id))
+    attributes = kc_admin_user.get("attributes", {}) if kc_admin_user else {}
+
+    def _attr(key: str) -> str:
+        val = attributes.get(key, "")
+        if isinstance(val, list):
+            return val[0] if val else ""
+        return str(val) if val else ""
+
+    return UserProfile(
+        id=user_id,
+        preferred_username=kc_user["preferred_username"],
+        email=kc_user["email"],
+        first_name=kc_user.get("given_name") or "",
+        last_name=kc_user.get("family_name") or "",
+        email_verified=kc_user["email_verified"],
+        address=Address(
+            street=_attr("street"),
+            postal_code=_attr("postal_code"),
+            locality=_attr("locality"),
+            region=_attr("region"),
+            country=_attr("country"),
+        ),
+    )
+
+
 async def update_user_profile(
     payload: UpdateUserProfileRequest,
     auth: Tuple[AuthUser, str],
     session: AsyncSession,
 ) -> Response:
     """
-    update the profile information for the authenticated user.
+    Update the profile information for the authenticated user.
 
     Args:
         payload: The user profile data to update
@@ -56,12 +143,11 @@ async def update_user_profile(
         stripe_user_mutation_repo = StripeUserMutationRepository(db_session=session)
 
         kc_user = await user_query_repo.get_user(user_id=str(user_id))
-
         if not kc_user:
             raise EntityNotFound
 
-        update_data: Dict[str, Any] = {}
-        update_data["email"] = payload.email
+        # Build Keycloak update payload
+        update_data: Dict[str, Any] = {"email": payload.email}
         if payload.first_name is not None:
             update_data["firstName"] = payload.first_name
         if payload.last_name is not None:
@@ -71,83 +157,44 @@ async def update_user_profile(
         merged_attributes = {
             k: v if isinstance(v, list) else [str(v)] for k, v in attributes.items()
         }
-
         merged_attributes["country"] = [payload.country]
 
         if payload.address is not None:
-            address_fields = {
-                "street": payload.address.street,
-                "postal_code": payload.address.postal_code,
-                "locality": payload.address.locality,
-                "region": payload.address.region,
-            }
-
             address_updates = {
-                k: [v] for k, v in address_fields.items() if v is not None
+                k: [v]
+                for k, v in {
+                    "street": payload.address.street,
+                    "postal_code": payload.address.postal_code,
+                    "locality": payload.address.locality,
+                    "region": payload.address.region,
+                }.items()
+                if v is not None
             }
             merged_attributes.update(address_updates)
 
         update_data["attributes"] = merged_attributes
 
-        if update_data:
-            await user_mutation_repo.Kc.a_update_user(
-                user_id=str(user_id),
-                payload=update_data,
-            )
-
-            kc_user = cast(
-                Dict[str, Any], await user_query_repo.get_user_info(token=token)
-            )
-
-        # Fetch user via admin API to get attributes (address fields)
-        kc_admin_user = await user_query_repo.get_user(user_id=str(user_id))
-        attributes = kc_admin_user.get("attributes", {}) if kc_admin_user else {}
-
-        def _attr(key: str) -> str:
-            val = attributes.get(key, "")
-            if isinstance(val, list):
-                return val[0] if val else ""
-            return str(val) if val else ""
-
-        customer = await stripe_user_repo.get_by_user_id(
+        kc_user = await _apply_kc_update(
             user_id=user_id,
+            token=token,
+            update_data=update_data,
+            user_query_repo=user_query_repo,
+            user_mutation_repo=user_mutation_repo,
         )
 
-        if customer is None:
-            stripe_customer = await stripe_service.create_customer(
-                user_id=user_id,
-                email=payload.email,
-                name=f"{payload.first_name or kc_user.get('given_name')} {payload.last_name or kc_user.get('family_name')}",
-            )
-            if stripe_customer is None:
-                raise EntityNotCreated("Stripe customer creation failed")
+        await _sync_stripe_customer(
+            user_id=user_id,
+            email=payload.email,
+            name=f"{payload.first_name or kc_user.get('given_name')} {payload.last_name or kc_user.get('family_name')}",
+            stripe_user_repo=stripe_user_repo,
+            stripe_service=stripe_service,
+            stripe_user_mutation_repo=stripe_user_mutation_repo,
+        )
 
-            await stripe_user_mutation_repo.create(
-                user_id=user_id,
-                stripe_customer_id=stripe_customer.id,
-            )
-        else:
-            assert customer.stripe_customer_id, "Customer not found"
-            stripe_customer = await stripe_service.update_customer(
-                customer_id=customer.stripe_customer_id,
-                name=f"{payload.first_name or kc_user.get('given_name')} {payload.last_name or kc_user.get('family_name')}",
-                email=payload.email,
-            )
-
-        user_profile = UserProfile(
-            id=user_id,
-            preferred_username=kc_user["preferred_username"],
-            email=kc_user["email"],
-            first_name=kc_user.get("given_name") or "",
-            last_name=kc_user.get("family_name") or "",
-            email_verified=kc_user["email_verified"],
-            address=Address(
-                street=_attr("street"),
-                postal_code=_attr("postal_code"),
-                locality=_attr("locality"),
-                region=_attr("region"),
-                country=_attr("country"),
-            ),
+        user_profile = await _build_user_profile(
+            user_id=user_id,
+            kc_user=kc_user,
+            user_query_repo=user_query_repo,
         )
 
         return VliResponse.new(
@@ -173,13 +220,110 @@ async def update_user_profile(
             isinstance(e.response_body, str)
             and "User exists with same email" in e.response_body
         ):
-            message = "This email address cannot be used. Try another one or sign in if you already have an account."
+            message = "We’re unable to update your profile with this email address. Please make sure the email is correct or try another one."
 
         raise VliError(
             error_code=VliErrorCode.DATA_CONFLICT,
             http_status_code=HTTPStatus.CONFLICT,
             message=message,
         ) from e
+    except KeycloakError as e:
+        logger.error(f"Keycloak error: {str(e)}")
+        raise VliError(
+            error_code=VliErrorCode.ENTITY_UPDATE__ERROR,
+            http_status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
+            message=str(e) or "An error occurred while updating the user profile",
+        ) from e
+    except Exception as e:
+        logger.exception(f"Error updating user profile: {str(e)}")
+        raise VliError(
+            error_code=VliErrorCode.INTERNAL_SERVER_ERROR,
+            http_status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
+            message="An error occurred while updating the user profile",
+        )
+
+
+async def onboarding_update_user_profile(
+    payload: OnboardingUpdateUserProfileRequest,
+    auth: Tuple[AuthUser, str],
+    session: AsyncSession,
+) -> Response:
+    """
+    Update the profile information during onboarding.
+    Only allows updating first_name, last_name, and country.
+
+    Args:
+        payload: The onboarding profile data to update
+        auth: auth tuple
+
+    Returns:
+        Response: updated user profile information
+    """
+    try:
+        _, token = auth
+        user_id = get_user_id_from_auth(auth)
+        user_query_repo = UserQueryRepository()
+        user_mutation_repo = UserMutationRepository()
+        stripe_user_repo = StripeUserQueryRepository(db_session=session)
+        stripe_service = get_stripe_repository()
+        stripe_user_mutation_repo = StripeUserMutationRepository(db_session=session)
+
+        kc_user = await user_query_repo.get_user(user_id=str(user_id))
+        if not kc_user:
+            raise EntityNotFound
+
+        # Build Keycloak update payload (email stays unchanged)
+        update_data: Dict[str, Any] = {"email": kc_user.get("email")}
+        if payload.first_name is not None:
+            update_data["firstName"] = payload.first_name
+        if payload.last_name is not None:
+            update_data["lastName"] = payload.last_name
+
+        attributes = kc_user.get("attributes", {}) or {}
+        merged_attributes = {
+            k: v if isinstance(v, list) else [str(v)] for k, v in attributes.items()
+        }
+        if payload.country is not None:
+            merged_attributes["country"] = [payload.country]
+
+        update_data["attributes"] = merged_attributes
+
+        kc_user = await _apply_kc_update(
+            user_id=user_id,
+            token=token,
+            update_data=update_data,
+            user_query_repo=user_query_repo,
+            user_mutation_repo=user_mutation_repo,
+        )
+
+        user_profile = await _build_user_profile(
+            user_id=user_id,
+            kc_user=kc_user,
+            user_query_repo=user_query_repo,
+        )
+
+        # Sync Stripe customer name if first_name or last_name changed
+        if payload.first_name is not None or payload.last_name is not None:
+            await _sync_stripe_customer(
+                user_id=user_id,
+                email=kc_user["email"],
+                name=f"{user_profile.first_name} {user_profile.last_name}",
+                stripe_user_repo=stripe_user_repo,
+                stripe_service=stripe_service,
+                stripe_user_mutation_repo=stripe_user_mutation_repo,
+            )
+
+        return VliResponse.new(
+            message="User profile updated successfully",
+            data=UserProfileResponse(profile=user_profile).model_dump(),
+        )
+    except EntityNotFound as e:
+        logger.error(f"User not found: {str(e)}")
+        raise VliError(
+            error_code=VliErrorCode.ENTITY_NOT_FOUND,
+            http_status_code=HTTPStatus.NOT_FOUND,
+            message="User not found",
+        )
     except KeycloakError as e:
         logger.error(f"Keycloak error: {str(e)}")
         raise VliError(


### PR DESCRIPTION
- profile endpoints
   - `PATCH /users/profile`: all fields now required: `email`, `country`, `first_name`, `last_name`
   - `PATCH /users/onboarding/profile`: all fields required: `email`, `country`, `first_name`, `last_name`
- country validation, `ISO 3166-1 alpha-2` code validation (exactly 2 chars, validated against country.json) on both endpoints
- emailVerified: true sent to Keycloak on email updates
- duplicate email handling, returns `409 Conflict` 
- virtual lab creation (atomicity fix)
**bug**: repository.create_virtual_lab() committed the db row immediately. If subsequent steps (subscription, kc attributes, stripe, email) failed, the vlab row persisted as an orphan, breaking user onboarding.
**fix**: use `flush()` instead of `commit()` in the repository. The commit is now deferred to the end of the use case after 
